### PR TITLE
Fixes minor issues and add support for SHA256 lookup

### DIFF
--- a/pyhashlookup/api.py
+++ b/pyhashlookup/api.py
@@ -42,12 +42,14 @@ class Hashlookup():
 
     def md5_lookup_over_dns(self, md5: str) -> Dict[str, Union[str, Dict[str, str]]]:
         '''Lookup a MD5, over DNS'''
+        md5 = md5.lower()
         answer = dns.resolver.resolve(f'{md5}.dns.hashlookup.circl.lu', 'TXT')  # type: ignore
         a = str(answer[0])
         return json.loads(json.loads(a))
 
     def sha1_lookup_over_dns(self, sha1: str) -> Dict[str, Union[str, Dict[str, str]]]:
         '''Lookup a SHA1, over DNS'''
+        sha1 = sha1.lower()
         answer = dns.resolver.resolve(f'{sha1}.dns.hashlookup.circl.lu', 'TXT')  # type: ignore
         a = str(answer[0])
         return json.loads(json.loads(a))
@@ -60,6 +62,11 @@ class Hashlookup():
     def sha1_lookup(self, sha1: str) -> Dict[str, Union[str, Dict[str, str]]]:
         '''Lookup a SHA1'''
         r = self.session.get(urljoin(self.root_url, str(Path('lookup', 'sha1', sha1))))
+        return r.json()
+
+    def sha256_lookup(self, sha256: str) -> Dict[str, Union[str, Dict[str, str]]]:
+        '''Lookup a SHA256'''
+        r = self.session.get(urljoin(self.root_url, str(Path('lookup', 'sha256', sha256))))
         return r.json()
 
     def md5_bulk_lookup(self, md5: List[str]) -> List[Dict[str, Union[str, Dict[str, str]]]]:
@@ -81,7 +88,9 @@ class Hashlookup():
                 return self.md5_lookup(to_lookup)
             elif len(to_lookup) == 40:
                 return self.sha1_lookup(to_lookup)
-            raise PyHashlookupError('The hash must be either MD5 or SHA1')
+            elif len(to_lookup) == 64:
+                return self.sha256_lookup(to_lookup)
+            raise PyHashlookupError('The hash must be either MD5, SHA1 or SHA256')
         elif isinstance(to_lookup, list):
             if all(len(lookup_hash) == 32 for lookup_hash in to_lookup):
                 return self.md5_bulk_lookup(to_lookup)

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -26,16 +26,19 @@ class UnitTesting(unittest.TestCase):
     def test_lookup(self) -> None:
         md5 = '8ED4B4ED952526D89899E723F3488DE4'
         sha1 = 'FFFFFDAC1B1B4C513896C805C2C698D9688BE69F'
+        sha256 = '301C9EC7A9AADEE4D745E8FD4FA659DAFBBCC6B75B9FF491D14CBBDD840814E9'
         bulk_md5 = ['6E2F8616A01725DCB37BED0A2495AEB2', '8ED4B4ED952526D89899E723F3488DE4', '344428FA4BA313712E4CA9B16D089AC4']
         bulk_sha1 = ['FFFFFDAC1B1B4C513896C805C2C698D9688BE69F', 'FFFFFF4DB8282D002893A9BAF00E9E9D4BA45E65', 'FFFFFE4C92E3F7282C7502F1734B243FA52326FB']
         response_md5: Dict[str, Union[str, Dict[str, str]]] = self.public_instance.lookup(md5)  # type: ignore
         response_sha1: Dict[str, Union[str, Dict[str, str]]] = self.public_instance.lookup(sha1)  # type: ignore
+        response_sha256: Dict[str, Union[str, Dict[str, str]]] = self.public_instance.lookup(sha256)  # type: ignore
         response_bulk_md5: List[Dict[str, Union[str, Dict[str, str]]]] = self.public_instance.lookup(bulk_md5)  # type: ignore
         response_bulk_sha1: List[Dict[str, Union[str, Dict[str, str]]]] = self.public_instance.lookup(bulk_sha1)  # type: ignore
 
         self.assertEqual(response_md5['CRC32'], '7A5407CA', response_md5)
 
         self.assertEqual(response_sha1['CRC32'], 'CBD64CD9', response_sha1)
+        self.assertEqual(response_sha256['MD5'], '34D827A288FA51B93297EF2A8A43B769', response_sha256)
 
         self.assertEqual(response_bulk_md5[0]['CRC32'], 'E774FD92', response_bulk_md5)
         self.assertEqual(response_bulk_md5[1]['CRC32'], '7A5407CA', response_bulk_md5)
@@ -46,16 +49,16 @@ class UnitTesting(unittest.TestCase):
         self.assertEqual(response_bulk_sha1[2]['CRC32'], '8E51A269', response_bulk_sha1)
 
     def test_dns_lookup(self) -> None:
-        md5 = '6E2F8616A01725DCB37BED0A2495AEB2'.lower()
+        md5 = '6E2F8616A01725DCB37BED0A2495AEB2'
         response_md5: Dict[str, Union[str, Dict[str, str]]] = self.public_instance.md5_lookup_over_dns(md5)
-        self.assertEqual(response_md5['CRC32'], 'E774FD92', response_md5)
+        self.assertEqual(response_md5['SHA-1'], '00000903319A8CE18A03DFA22C07C6CA43602061', response_md5)
 
-        sha1 = 'FFFFFDAC1B1B4C513896C805C2C698D9688BE69F'.lower()
+        sha1 = 'FFFFFDAC1B1B4C513896C805C2C698D9688BE69F'
         response_sha1: Dict[str, Union[str, Dict[str, str]]] = self.public_instance.sha1_lookup_over_dns(sha1)
-        self.assertEqual(response_sha1['CRC32'], 'CBD64CD9')
-        sha1 = 'FFFFFF4DB8282D002893A9BAF00E9E9D4BA45E65'.lower()
+        self.assertEqual(response_sha1['MD5'], '131312A96CAD4ACAA7E2631A34A0D47C')
+        sha1 = 'FFFFFF4DB8282D002893A9BAF00E9E9D4BA45E65'
         response_sha1 = self.public_instance.sha1_lookup_over_dns(sha1)
-        self.assertEqual(response_sha1['CRC32'], '8654F11A')
+        self.assertEqual(response_sha1['MD5'], '559D049F44942683093A91BA19D0AF54')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi,

This commit fixes a few things:
* Automatically lower the hash in DNS lookup
* Implement SHA256 lookup
* Fixes some tests with dns queries (they do not return CRC32 which is what was tested here)

Is there any plan to implement sha256 bulk lookup server side?